### PR TITLE
Removed Lease in Adalian Days stat

### DIFF
--- a/src/game/interface/hud/actionDialogs/FormAgreement.js
+++ b/src/game/interface/hud/actionDialogs/FormAgreement.js
@@ -201,11 +201,6 @@ const FormAgreement = ({
           direction: 0,
         },
         {
-          label: 'Lease Length (Adalian Days)',
-          value: Time.toGameDuration(monthsToSeconds(initialPeriod) / 86400, crew?._timeAcceleration).toLocaleString(),
-          direction: 0,
-        },
-        {
           label: 'Notice Period',
           value: isExtension
             ? `${currentAgreement?.noticePeriod || 0} month${currentAgreement?.noticePeriod === 1 ? '' : 's'}`


### PR DESCRIPTION
The "Adalian Days" unit was confusing when shown right next to "months" (Earth Months) for leases; let's remove it.

We also don't explain the conversion for Adalian Days anywhere.