### PR TITLE
Filter out unplanned building for available inventories

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -190,6 +190,9 @@ const api = {
     // BUILDINGS...
     const buildingQueryBuilder = esb.boolQuery();
 
+    // Exclude unplanned buildings
+    buildingQueryBuilder.mustNot(esb.termQuery('Building.status', Building.CONSTRUCTION_STATUSES.UNPLANNED))
+
     // has permission
     if (withPermission) buildingQueryBuilder.filter(esbPermissionQuery(crewId, withPermission));
 


### PR DESCRIPTION
## Summary
- updated `getCrewAccessibleInventories` to filter out building entities whose status is Unplanned

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206708170025540