### PR TITLE
Hide EjectCrew when in Emergency Mode

### DIFF
--- a/src/game/interface/hud/actionButtons/EjectCrew.js
+++ b/src/game/interface/hud/actionButtons/EjectCrew.js
@@ -7,6 +7,9 @@ import useEjectCrewManager from '~/hooks/actionManagers/useEjectCrewManager';
 const isVisible = ({ crew, building, ship }) => {
   if (crew) {
     if (ship) {
+      // do not display if ship in emergency mode
+      if (ship.Ship?.emergencyAt > 0) return false;
+
       // if my crew is on it, do i still need to check that status is available?
       return crew._location.shipId === ship.id;
     }


### PR DESCRIPTION
## Summary
- hide button if ship is in emergency mode

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206777118300256