### PR TITLE
Tooltip autohide for ActionButtons

### DIFF
--- a/src/game/interface/hud/actionButtons/ActionButton.js
+++ b/src/game/interface/hud/actionButtons/ActionButton.js
@@ -266,6 +266,7 @@ const ActionButtonComponent = ({ label, labelAddendum, flags = {}, icon, onClick
       data-arrow-color="transparent"
       data-tooltip-id="global"
       data-tooltip-place="top"
+      data-tooltip-delay-hide={100}
       data-tooltip-content={`${label}${labelAddendum ? ` (${labelAddendum})` : ''}`}
       onClick={_onClick}
       {...safeFlags}


### PR DESCRIPTION
## Summary
Tooltip is showing on top of input box and takes too long to hide.

- set tooltip to hide after 100ms

<img width="1912" alt="Screenshot 2024-04-24 at 10 40 36 AM" src="https://github.com/influenceth/client/assets/2538938/c6d5b53c-2be3-47bf-85c3-c98159f3c408">
