### PR TITLE
Fix mismatched banner and action item colors

### DIFF
--- a/src/game/interface/hud/ActionItem.js
+++ b/src/game/interface/hud/ActionItem.js
@@ -325,7 +325,7 @@ const ActionItem = ({ data, getActivityConfig }) => {
             item.finishTime
               ? (
                 <LiveTimer target={item.finishTime} maxPrecision={2}>
-                  {(formattedTime, isTimer) => isTimer ? <><b style={{ marginRight: 4 }}>Timer</b> {formattedTime}</> : <b>{formattedTime}</b>}
+                  {(formattedTime, isTimer) => isTimer ? <><b style={{ marginRight: 4 }}>Expiring In</b> {formattedTime}</> : <b>{formattedTime}</b>}
                 </LiveTimer>
               )
               : <b>Materials at Risk</b>
@@ -334,7 +334,7 @@ const ActionItem = ({ data, getActivityConfig }) => {
             item.finishTime
               ? (
                 <LiveTimer target={item.finishTime} maxPrecision={1}>
-                  {(formattedTime, isTimer) => isTimer ? <><b style={{ marginRight: 4 }}>Expiring in</b>{formattedTime}</> : <b>{formattedTime}</b>}
+                  {(formattedTime, isTimer) => isTimer ? <><b style={{ marginRight: 4 }}>Remaining</b>{formattedTime}</> : <b>{formattedTime}</b>}
                 </LiveTimer>
               )
               : <b>Expired</b>

--- a/src/game/interface/hud/InfoPane.js
+++ b/src/game/interface/hud/InfoPane.js
@@ -506,8 +506,8 @@ const InfoPane = () => {
           }
           else {
             thumbBanner = <><LiveTimer target={lot?.building?.Building?.plannedAt + Building.GRACE_PERIOD} /></>;
-            thumbBannerColor = 'lightPurple';
-            thumbBannerBackgroundColor = 'backgroundPurple';
+            thumbBannerColor = 'lightOrange';
+            thumbBannerBackgroundColor = 'backgroundOrange';
           }
         }
         pane.thumbVisible = true;

--- a/src/lib/actionItem.js
+++ b/src/lib/actionItem.js
@@ -1027,26 +1027,26 @@ export const formatActionItem = (item, actionItem) => {
 }
 
 export const itemColors = {
-  pending: hexToRGB(theme.colors.purple),
+  pending: hexToRGB(theme.colors.lightPurple),
   failed: '241, 131, 97',
   randomEvent: '232, 211, 117',
   ready: hexToRGB('#00fff0'),
   unready: theme.colors.brightMainRGB,
   unstarted: hexToRGB(theme.colors.sequence),
-  plan: '248, 133, 44',
-  agreement: '248, 133, 44',
+  plan: hexToRGB(theme.colors.lightOrange),
+  agreement: hexToRGB(theme.colors.orange),
   _expired: hexToRGB(theme.colors.red)
 };
 
 export const backgroundColors = {
-  pending: hexToRGB('#424278'),
+  pending: hexToRGB(theme.colors.backgroundPurple),
   failed: hexToRGB('#7a211c'),
   randomEvent: hexToRGB('#8c8148'),
   ready: hexToRGB('#006962'),
   unready: theme.colors.darkMainRGB,
   unstarted: hexToRGB('#1e558c'),
-  plan: hexToRGB('#80592c'),
-  agreement: hexToRGB('#853217'),
+  plan: hexToRGB(theme.colors.backgroundOrange),
+  agreement: hexToRGB(theme.colors.darkOrange),
   _expired: hexToRGB('#7a211c')
 };
 

--- a/src/theme.js
+++ b/src/theme.js
@@ -104,7 +104,7 @@ const theme = {
     blue, 
 
     yellow, 
-    backgroundYellow: '#80592c',
+    backgroundYellow: '#80612c',
 
     purple,
     lightPurple,  
@@ -112,11 +112,12 @@ const theme = {
 
     red, 
     darkRed, 
-    backgroundRed: '#471411',
+    backgroundRed: '#853430',
 
     orange, 
+    darkOrange: '#733813',
     lightOrange, 
-    backgroundOrange: '#853217',
+    backgroundOrange: '#593f24',
 
     green, 
     darkGreen,


### PR DESCRIPTION
- Set banner color to same light orange as action item
- Set correct light purple color for in progress items
- Adjusted expiring orange color to be more distinct
- Adjusted item vocab for clarity