### PR TITLE
Disable Administer Ship when busy

### DIFF
--- a/src/game/interface/hud/actionButtons/ControlShip.js
+++ b/src/game/interface/hud/actionButtons/ControlShip.js
@@ -11,7 +11,7 @@ const isVisible = ({ account, ship, crew }) => {
     && crew?.id && ship.Control?.controller?.id !== crew?.id;
 };
 
-const ControlShip = ({ ship, onSetAction, _disabled }) => {
+const ControlShip = ({ crew, ship, onSetAction, _disabled, ...props }) => {
   const { takingControl } = useControlShip(ship?.id);
 
   const handleClick = useCallback(() => {
@@ -21,8 +21,9 @@ const ControlShip = ({ ship, onSetAction, _disabled }) => {
   const disabledReason = useMemo(() => {
     if (_disabled) return 'loading...';
     if (takingControl) return 'updating...';
+    if (!crew?._ready) return 'crew is busy';
     return '';
-  }, [_disabled, takingControl]);
+  }, [crew, _disabled, takingControl]);
 
   // only flash green if no controller... button is always present if you own and
   // do not currently have control (hopefully that is less distracting when admin'ed


### PR DESCRIPTION
## Summary
- disable Administer Ship when crew is busy

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208002381119317