### PR TITLE
Extract dialog sway amount formatting

### DIFF
--- a/src/game/interface/hud/actionDialogs/Extract.js
+++ b/src/game/interface/hud/actionDialogs/Extract.js
@@ -525,7 +525,7 @@ const Extract = ({ asteroid, lot, extractionManager, stage, ...props }) => {
                 bottomBanner: leasePayment > 0 && (
                   <>
                     <SwayIcon />
-                    {formatFixed(leasePayment / 1e6, 1)}
+                    {formatFixed(leasePayment / 1e6, 0)}
                   </>
                 ),
                 iconBadge: <AgreementIcon />,


### PR DESCRIPTION
## Summary
- round up to nearest whole number for sway display on the extractor lease amount

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208261632431159