### PR TITLE
Add source amounts and bottleneck highlighting to processes

### DIFF
--- a/src/game/interface/hud/actionDialogs/components.js
+++ b/src/game/interface/hud/actionDialogs/components.js
@@ -4514,6 +4514,8 @@ export const ProcessInputOutputSection = ({ title, products, input, output, prim
       <ProductWrapper horizontalScroll={products?.length > 7}>
         {products.map(({ i: resourceId, recipe, amount }) => {
           const thumbProps = {};
+          const resource = Product.TYPES[resourceId];
+          let denominator = null;
           if (output) {
             thumbProps.backgroundColor = `rgba(${hexToRGB(theme.colors.green)}, 0.15)`;
             thumbProps.badgeColor = theme.colors.green;
@@ -4530,7 +4532,13 @@ export const ProcessInputOutputSection = ({ title, products, input, output, prim
               thumbProps.tooltipOverride = `[INSUFFICIENT] ${Product.TYPES[resourceId]?.name}`;
             }
           }
-          const resource = Product.TYPES[resourceId];
+          if (!output && stage == actionStage.NOT_STARTED) {
+            denominator = resource.isAtomic ? sourceContents[resourceId] || '0' : formatResourceMass(sourceContents[resourceId], resourceId);
+            if (amount + recipe >= sourceContents[resourceId] && sourceContents[resourceId] >= amount) {
+              thumbProps.backgroundColor = `rgba(${hexToRGB(theme.colors.warning)}, 0.15)`;
+              thumbProps.badgeColor = theme.colors.warning;
+            }
+          }
           return (
             <ProductSelector
               key={resourceId}
@@ -4541,6 +4549,7 @@ export const ProcessInputOutputSection = ({ title, products, input, output, prim
               <ResourceThumbnail
                 resource={resource}
                 badge={`${output ? '+' : '-'}${resource.isAtomic ? amount : formatResourceMass(amount, resourceId)}`}
+                badgeDenominator={denominator}
                 iconBadge={<RecipeLabel>{recipe.toLocaleString()}</RecipeLabel>}
                 tooltipContainer="actionDialogTooltip"
                 {...thumbProps}


### PR DESCRIPTION
**Original Feature Request:** https://discord.com/channels/814990637178290177/1314730372658888705

- added conditional for adding denominator + warning colors

**Description:**
A common pain point when manufacturing is not knowing which product is causing a bottleneck. The current work flow requires a time consuming comparison of amounts shown vs contents of the source location or by using 3rd party tools. This PR addresses this in two ways:

1. The source amount is now shown as the denominator for inputs. A user can easily evaluate what resources are needed without needing to inspect the source location
2. Any input amount that is within one SR of source amount is highlighted with the warning color to bring attention to immediate bottlenecks

This does not affect outputs or processes that have been started

![bottleneck-1](https://github.com/user-attachments/assets/c6c3bd98-be55-44e7-a7a1-20964234a862)
![bottleneck-2](https://github.com/user-attachments/assets/fd6d4199-2551-4f7a-922a-2dbfc1f354e5)
![bottleneck-3](https://github.com/user-attachments/assets/a7255186-0fa1-46e6-9ec4-fda03d070e55)


